### PR TITLE
Add example jupyter notebook and quarto docs to page

### DIFF
--- a/docs/Jupyter_notebooks/CampusResidentialWaterUseAnalysis_Complete.ipynb
+++ b/docs/Jupyter_notebooks/CampusResidentialWaterUseAnalysis_Complete.ipynb
@@ -1,0 +1,165 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Analysis of Weekday Versus Weekend Water use in a College Campus Residential Building"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Import the necessary Python libraries for the analysis"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import pandas\n",
+    "import matplotlib.pyplot as plt"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Read the CSV data file into a Pandas data frame object"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "df = pandas.read_csv('datalog_richards_hall.csv', header=1, sep=',',\n",
+    "                     index_col=0, parse_dates=True,\n",
+    "                     infer_datetime_format=True, low_memory=False)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "First aggregate the incremental flow volume to a total volume for each hourly time step for the whole period"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "hourlyTotVol = df['IncrementalVolume'].resample('1H', origin='start_day').sum()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Now subset the hourly data by days of the week create a new DataFrame for weekdays and one for weekends"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "weekday_dat = hourlyTotVol[hourlyTotVol.index.weekday < 5].copy()\n",
+    "weekend_dat = hourlyTotVol[hourlyTotVol.index.weekday >= 5].copy()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Calculate an average volume and standard deviation for each hour of the day by aggregating across days using the groupby function - for both weekday and weekend"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "hourlyAvgWeekdayVol = weekday_dat.groupby(weekday_dat.index.hour).mean()\n",
+    "hourlyAvgWeekendVol = weekend_dat.groupby(weekend_dat.index.hour).mean()\n",
+    "hourlyWeekdayStDevVol = weekday_dat.groupby(weekday_dat.index.hour).std()\n",
+    "hourlyWeekendStDevVol = weekend_dat.groupby(weekend_dat.index.hour).std()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Create an errorbar plot to which I can add all of the data subsets"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Set the default font size for the plot\n",
+    "font = {'size': 16}\n",
+    "plt.rc('font', **font)\n",
+    "\n",
+    "# Generate a single plot to which I can add all of the data subsets\n",
+    "fig = plt.figure(figsize=(10,5))\n",
+    "ax = fig.add_subplot(1, 1, 1)\n",
+    "\n",
+    "# Create an errorbar plot (lines, point, and errorbars) of the hourly average volumes\n",
+    "plt.errorbar(x=hourlyAvgWeekdayVol.index-0.05, y=hourlyAvgWeekdayVol, yerr=hourlyWeekdayStDevVol,\n",
+    "             capsize=3, capthick=0.5, fmt='--', label='Average Hourly Weekday Volumes', marker='o')\n",
+    "plt.errorbar(x=hourlyAvgWeekendVol.index+0.05, y=hourlyAvgWeekendVol, yerr=hourlyWeekendStDevVol,\n",
+    "             capsize=3, capthick=0.5, fmt='--', label='Average Hourly Weekend Volumes', marker='s')\n",
+    "\n",
+    "# Set the x-axis tic mark locations\n",
+    "ax.set_xlim(-0.5, 23.5)\n",
+    "xmarks = range(0, 23 + 1, 1)\n",
+    "plt.xticks(xmarks)\n",
+    "\n",
+    "# Set the x and y-axis labels\n",
+    "ax.set_ylabel('Average Hourly Volume (gal)')\n",
+    "ax.set_xlabel('Hour of the Day')\n",
+    "ax.grid(False)\n",
+    "\n",
+    "# Add a legend with some customizations\n",
+    "legend = ax.legend(loc='upper right', shadow=True)\n",
+    "\n",
+    "fig.tight_layout()\n",
+    "\n",
+    "# Make sure the plot displays\n",
+    "plt.show()"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.7.8"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/environment.yml
+++ b/environment.yml
@@ -9,3 +9,6 @@ dependencies:
       - mkdocs
       - mkdocs-material
       - mkdocs-git-revision-date-localized-plugin
+      - mkdocs-jupyter
+      - mkquartodocs
+

--- a/environment.yml
+++ b/environment.yml
@@ -5,10 +5,15 @@ channels:
 dependencies:
   - python=3.10
   - pip
+  - r-base=4.1
+  - r-knitr
+  - r-tidyverse
+  - r-irkernel
   - pip:
       - mkdocs
       - mkdocs-material
       - mkdocs-git-revision-date-localized-plugin
       - mkdocs-jupyter
       - mkquartodocs
-
+      - pandas
+      - matplotlib

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -29,8 +29,9 @@ plugins:
   - git-revision-date-localized:
       locale: en
       type: datetime
-  - mkdocs-jupyter
-  - mkquartodocs
+  - mkdocs-jupyter:
+      execute: true
+  # - mkquartodocs
 
 markdown_extensions:
   - tables
@@ -42,3 +43,9 @@ nav:
       - "[AIMS] Surface Water Chemistry Field Sampling": Protocols/Surface-Water-Quality/AIMS_SOP_Surface_Water_Chemistry_Field_Sampling.md
     - "Ecological & Biological Monitoring": 
       - "[AIMS] Benthic Macroinvertebrate Field Sampling": Protocols/Ecological-Biological-Monitoring/AIMS_SOP_Benthic_Macroinvertebrate_Field_Sampling.md
+  - "Jupyter Notebooks":
+    - "Example notebooks from HydroShare": 
+      - "Campus Residential Water Use Analysis": Jupyter_notebooks/CampusResidentialWaterUseAnalysis_Complete.ipynb
+  # - "Quarto Docs":
+  #   - "JP Gannon hydroinformatics course": 
+  #     - "Intro to plotting": Quarto_docs/01-Plotting_Demo_COMPLETE.qmd

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -28,7 +28,9 @@ plugins:
   - search
   - git-revision-date-localized:
       locale: en
-      type: datetime  
+      type: datetime
+  - mkdocs-jupyter
+  - mkquartodocs
 
 markdown_extensions:
   - tables


### PR DESCRIPTION
Closes #7 and #8. We are able to render Jupyter notebooks and Quarto docs on the Mkdocs page, however we are unable to modify this content through Decap CMS via modifications to the `config.yml` file . I haven't found official documentation here but it appears that Decap CMS only supports for rich text to markdown based edits. Will add more info to this PR thread if I find additional documentation